### PR TITLE
Add knockback

### DIFF
--- a/src/ServerScriptService/attack_player.server.luau
+++ b/src/ServerScriptService/attack_player.server.luau
@@ -1,9 +1,45 @@
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local RunService = game:GetService("RunService")
 
 local play_sound_excluding = require(script.Parent.modules.play_sound_excluding)
 local player_range_server = require(script.Parent.modules.player_range_server)
 
-local DAMAGE = 10
+local damage = 10
+local knockback_pitch_range = NumberRange.new(30, 100)
+local knockback_yaw_magnitude = 30
+
+local function clamp_range(n: number, range: NumberRange): number
+	return math.clamp(n, range.Min, range.Max)
+end
+
+type delay = {
+	frames: number,
+	callback: () -> (),
+}
+local delays: {delay} = {}
+local function delay_for_frames(frames: number, callback: () -> ()): ()
+	table.insert(delays, {
+		frames = frames,
+		callback = callback,
+	})
+end
+
+local function on_heartbeat(): ()
+	local indices_garbage = {}
+	for index, delay in delays do
+		delay.frames -= 1
+		if delay.frames <= 0 then
+			delay.callback()
+			table.insert(indices_garbage, index)
+		end
+	end
+	local offset = 0
+	for _, index in indices_garbage do
+		table.remove(delays, index - offset)
+		offset += 1
+	end
+end
+RunService.Heartbeat:Connect(on_heartbeat)
 
 local function on_event(player: Player, target_character: unknown): ()
 	if typeof(target_character) ~= "Instance" then
@@ -33,7 +69,9 @@ local function on_event(player: Player, target_character: unknown): ()
 
 	local attacker_position = attacker_root.CFrame.Position
 	
-	local distance = (target_position - attacker_position).Magnitude
+	local attack_vector = target_position - attacker_position
+	
+	local distance = attack_vector.Magnitude
 	if distance > player_range_server then
 		return
 	end
@@ -43,7 +81,18 @@ local function on_event(player: Player, target_character: unknown): ()
 		return
 	end
 
-	target_humanoid.Health -= DAMAGE
+	target_humanoid.Health -= damage
+
+	local knockback_pitch_value = clamp_range(attack_vector.Y, knockback_pitch_range)
+	local knockback_pitch = Vector3.new(0, knockback_pitch_value, 0)
+	target_root.AssemblyLinearVelocity += knockback_pitch
+
+	local attack_yaw = Vector3.new(attack_vector.X, 0, attack_vector.Z)
+	local knockback_yaw = attack_yaw.Unit * knockback_yaw_magnitude
+	local function apply_yaw(): ()
+		target_root.AssemblyLinearVelocity += knockback_yaw
+	end
+	delay_for_frames(10, apply_yaw)
 
 	play_sound_excluding(player, "player_damaged", attacker_position)
 end

--- a/src/ServerScriptService/test_attacking.server.luau
+++ b/src/ServerScriptService/test_attacking.server.luau
@@ -1,0 +1,35 @@
+local Players = game:GetService("Players")
+local RunService = game:GetService("RunService")
+
+-- This is helpful:
+-- > local humanoid = workspace:FindFirstChild("clone of Ethical_Eli").Humanoid humanoid.Health = humanoid.MaxHealth
+-- (Make sure to run in server.)
+
+local enabled = false
+if RunService:IsStudio() and enabled then
+	local function clone_maybe_not_archivable<T>(instance: T & Instance): T
+		local archivable = instance.Archivable
+		instance.Archivable = true
+		local clone = instance:Clone()
+		instance.Archivable = archivable
+		return clone
+	end
+
+	local function on_player_added(player: Player): ()
+		local function on_character(character: Model): ()
+			local clone = clone_maybe_not_archivable(character)
+			clone.Name = `clone of {character.Name}`
+
+			clone:PivotTo(character:GetPivot() * CFrame.new(Vector3.new(3, 0, 0)))
+			clone.Parent = workspace
+		end
+
+		if player.Character ~= nil and player:HasAppearanceLoaded() then
+			on_character(player.Character)
+		else
+			player.CharacterAppearanceLoaded:Once(on_character)
+		end
+	end
+
+	Players.PlayerAdded:Connect(on_player_added)
+end


### PR DESCRIPTION
Knock players back when they are attacked meleely.

Right now, it is kind of goofy since the server has to wait before applying x-axis and z-axis (hereby "yaw") knockback due to friction, so it is waiting for the character to move up enough. I am creating this pull request so that others can give their input and perhaps try investigating the issue; otherwise, I think it is fine to merge anyway since the knockback can always be improved later, and I think it is not *terrible* right now.